### PR TITLE
add support for parsing strings into UUID objects

### DIFF
--- a/libuuid/_uuid.pyx
+++ b/libuuid/_uuid.pyx
@@ -21,13 +21,20 @@ cdef extern from "Python.h":
 
 
 class FastUUID(uuid_std.UUID):
-    def __init__(self, version=4, *args, **kwargs):
+
+    def __init__(self, uuid_str=None, int version=4, *args, **kwargs):
+
         cdef object buf = PyString_FromStringAndSize(NULL, 16)
         cdef unsigned char *_bytes = <unsigned char*>PyString_AS_STRING(buf)
-        if version == 1:
-            uuid_generate_time(_bytes)
-        elif version == 4:
-            uuid_generate_random(_bytes)
+
+        if uuid_str:
+            uuid_parse(uuid_str, _bytes)
+        else:
+            if version == 1:
+                uuid_generate_time(_bytes)
+            elif version == 4:
+                uuid_generate_random(_bytes)
+
         self.__dict__['bytes'] = buf
         self.__dict__['int'] = _PyLong_FromByteArray(_bytes, 16, 0, 0)
 
@@ -35,10 +42,17 @@ class FastUUID(uuid_std.UUID):
         return self.bytes
 
 
+def parse_many(uuid_strings):
+    uuids = []
+    for uuid_str in uuid_strings:
+        uuids.append(FastUUID(uuid_str))
+    return uuids
+
+
 def uuid1(node=None, clock_seq=None):
     if node or clock_seq:
         raise NotImplementedError, "node and clock_seq are not supported in libuuid"
-    return FastUUID(1)
+    return FastUUID(version=1)
 
 uuid3 = uuid_std.uuid3
 

--- a/tests/test_uuid.py
+++ b/tests/test_uuid.py
@@ -50,6 +50,12 @@ def test_constants():
 
 class TestUUID(unittest.TestCase):
 
+    def test_uuid_parse(self):
+        u = libuuid.FastUUID('d7cfb958-8cb5-477c-b7ec-80ecaf1c8d67')
+        u2 = uuid.UUID('d7cfb958-8cb5-477c-b7ec-80ecaf1c8d67')
+        self.assertEqual(u.bytes, u2.bytes)
+        self.assertEqual(u, u2)
+
     def test_uuid1(self):
         u = libuuid.uuid1()
         u2 = uuid.UUID(bytes=u.bytes)


### PR DESCRIPTION
Adds support for:

```python
libuuid.FastUUID('d7cfb958-8cb5-477c-b7ec-80ecaf1c8d67')
```

which is 2x faster than

```python
import uuid
uuid.UUID('d7cfb958-8cb5-477c-b7ec-80ecaf1c8d67')
```